### PR TITLE
feat: support umi mfsu

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,31 +9,31 @@ export default (api) => {
     stage: -1 * Number.MAX_SAFE_INTEGER,
   })
 
-//   // 因 keep-alive 的 runtime 部分选择不渲染其 children，可能会丢失默认的用户 rootContainer
-//   // 此处修复自定义 rootContainer
-//   // https://github.com/umijs/umi/blob/master/packages/preset-built-in/src/plugins/generateFiles/core/plugin.ts#L23-L27
-//   const customizedAppPath = getFile({
-//     base: api.paths.absSrcPath,
-//     fileNameWithoutExt: 'app',
-//     type: 'javascript',
-//   })?.path
+  //   // 因 keep-alive 的 runtime 部分选择不渲染其 children，可能会丢失默认的用户 rootContainer
+  //   // 此处修复自定义 rootContainer
+  //   // https://github.com/umijs/umi/blob/master/packages/preset-built-in/src/plugins/generateFiles/core/plugin.ts#L23-L27
+  //   const customizedAppPath = getFile({
+  //     base: api.paths.absSrcPath,
+  //     fileNameWithoutExt: 'app',
+  //     type: 'javascript',
+  //   })?.path
 
-//   if (customizedAppPath) {
-//     api.addRuntimePlugin({
-//       fn: () => '@@/plugin-keep-alive/fixCustomizedRuntime',
-//       stage: -1 * Number.MAX_SAFE_INTEGER + 1,
-//     })
+  //   if (customizedAppPath) {
+  //     api.addRuntimePlugin({
+  //       fn: () => '@@/plugin-keep-alive/fixCustomizedRuntime',
+  //       stage: -1 * Number.MAX_SAFE_INTEGER + 1,
+  //     })
 
-//     api.onGenerateFiles(async () => {
-//       api.writeTmpFile({
-//         path: 'plugin-keep-alive/fixCustomizedRuntime.tsx',
-//         content: utils.Mustache.render(
-//           readFileSync(join(__dirname, 'fixCustomizedRuntime.tsx.tpl'), 'utf-8'),
-//           {},
-//         ),
-//       })
-//     })
-//   }
+  //     api.onGenerateFiles(async () => {
+  //       api.writeTmpFile({
+  //         path: 'plugin-keep-alive/fixCustomizedRuntime.tsx',
+  //         content: utils.Mustache.render(
+  //           readFileSync(join(__dirname, 'fixCustomizedRuntime.tsx.tpl'), 'utf-8'),
+  //           {},
+  //         ),
+  //       })
+  //     })
+  //   }
 
   // Babel Plugin for react-activation
   api.modifyBabelOpts((babelOpts) => {
@@ -42,10 +42,18 @@ export default (api) => {
   })
 
   // 生成：export * from 'react-activation'
+  // TODO: 指明支持的 api，使用上述方式存在 bug https://github.com/guybedford/es-module-lexer/issues/76
   // 业务中可 import { KeepAlive } from 'umi'
   api.addUmiExports(() => [
     {
-      exportAll: true,
+      specifiers: [
+        'KeepAlive',
+        'useActivate',
+        'useUnactivate',
+        'withActivation',
+        'withAliveScope',
+        'useAliveController'
+      ],
       source: 'react-activation',
     },
   ])


### PR DESCRIPTION
支持 umi@3.5 mfsu
只是修改了导出方式，不对任何逻辑产生影响。
因为 `export * from 'react-activation'` 的导出方式，lexer 暂时无法识别，相关 Issues https://github.com/guybedford/es-module-lexer/issues/76，相关Issues修复后，也无需修改这里的导出方式。（除非 `react-activation` 新增新的 API。）

Close: https://github.com/alitajs/umi-plugin-keep-alive/issues/49